### PR TITLE
ci(jenkins): fixes sanity check

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
     stage('Sanity checks') {
       environment {
         HOME = "${env.WORKSPACE}"
+        PATH = "${env.HOME}/bin:${env.PATH}"
       }
       options { skipDefaultCheckout() }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,6 +34,9 @@ pipeline {
       }
     }
     stage('Sanity checks') {
+      environment {
+        HOME = "${env.WORKSPACE}"
+      }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,16 +33,6 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('Sanity checks') {
-      options { skipDefaultCheckout() }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
-        }
-      }
-    }
     stage('Parallel'){
       parallel {
         stage('Test-7.2') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,6 +33,16 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
+    stage('Sanity checks') {
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+        }
+      }
+    }
     stage('Parallel'){
       parallel {
         stage('Test-7.2') {


### PR DESCRIPTION
I guess, we might need to fix the shared library to ensure the env variable is passed otherwise:


```
18:06:28  + python -
18:06:28  + curl https://pre-commit.com/install-local.py
18:06:28    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
18:06:28                                   Dload  Upload   Total   Spent    Left  Speed
18:06:28  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  2590  100  2590    0     0  11511      0 --:--:-- --:--:-- --:--:-- 11511
18:06:28  Traceback (most recent call last):
18:06:28    File "<stdin>", line 103, in <module>
18:06:28    File "<stdin>", line 64, in main
18:06:28    File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
18:06:28      raise KeyError(key)
18:06:28  KeyError: u'HOME'
```