### PR TITLE
Updated implementation to keep it compatible with the latest ECS logging spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,26 @@
+# Composer
 composer.lock
+composer.phar
 vendor/
+
+# JetBrains PhpStorm
+.idea/
+
+# Visual Studio Code
+.vscode/
+
+# Generated files
+_GENERATED/
+
+# PHPUnit
 .phpunit.result.cache
 junit-*.xml
+
+# PHP_CodeSniffer
+.php_cs.cache
+
+# Built documentation
+html_docs
+
+# Mac
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
             "name": "Philip Krauss",
             "email": "philip.krauss@elastic.co",
             "homepage": "https://github.com/philkra"
+        },
+        {
+            "name": "Sergey Kleyman",
+            "homepage": "https://github.com/SergeyKleyman"
         }
     ],
     "require": {
@@ -34,10 +38,10 @@
     },
     "scripts": {
         "test": [
-            "./vendor/bin/parallel-lint . --exclude vendor",
-            "./vendor/bin/phpcs --standard=phpcs.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp src/Elastic",
-            "./vendor/bin/phpcs --standard=phpcs.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp tests/Elastic",
-            "./vendor/bin/paratest -c phpunit.xml.dist --bootstrap tests/bootstrap.php --log-junit=junit-${VERSION}.xml"
+            "parallel-lint . --exclude vendor",
+            "phpcs --standard=phpcs.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp src/Elastic",
+            "phpcs --standard=phpcs.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp tests/Elastic",
+            "paratest -c phpunit.xml.dist --bootstrap tests/bootstrap.php --log-junit=junit-${VERSION}.xml"
         ]
     },
     "config": {

--- a/docs/Monolog_v2.md
+++ b/docs/Monolog_v2.md
@@ -4,7 +4,7 @@
 ```php
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
-use Elastic\Monolog\v2\Formatter\ElasticCommonSchemaFormatter;
+use Elastic\Monolog\Formatter\ElasticCommonSchemaFormatter;
 
 $logger = new Logger('my_ecs_logger');
 $formatter = new ElasticCommonSchemaFormatter();

--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -101,18 +101,19 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
         // Add ECS Labels
         $inContext = $inRecord['context'];
         if (!empty($inContext)) {
-            if (array_key_exists('labels', $inContext)) {
-                $outLabels = [];
-                foreach ($inContext['labels'] as $key => $val) {
-                    $outLabels[str_replace(['.', ' ', '*', '\\'], '_', trim($key))] = $val;
-                }
-                $outRecord['labels'] = $outLabels;
-            }
-
             // Context should go to the top of the out record
-            // We don't use array_merge to preserve the order (for better human readability)
-            foreach ($inContext as $key => $val) {
-                $outRecord[$key] = $val;
+            foreach ($inContext as $contextKey => $contextVal) {
+                // label keys should be sanitized
+                if ($contextKey === 'labels') {
+                    $outLabels = [];
+                    foreach ($contextVal as $labelKey => $labelVal) {
+                        $outLabels[str_replace(['.', ' ', '*', '\\'], '_', trim($labelKey))] = $labelVal;
+                    }
+                    $outRecord['labels'] = $outLabels;
+                    continue;
+                }
+
+                $outRecord[$contextKey] = $contextVal;
             }
         }
 

--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -48,9 +48,9 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
      * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-base.html
      * @link https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
      */
-    public function format(array $inRecord): string
+    public function format(array $record): string
     {
-        $inRecord = $this->normalize($inRecord);
+        $inRecord = $this->normalize($record);
 
         // Build Skeleton with "@timestamp" and "log.level"
         $outRecord = [

--- a/tests/sample_app/sample_app.php
+++ b/tests/sample_app/sample_app.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . './../bootstrap.php';
+
+use Elastic\Monolog\Formatter\ElasticCommonSchemaFormatter;
+use Elastic\Types\Error as EcsError;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+$log = new Logger('MyLogger');
+$handler = new StreamHandler('php://stdout', Logger::DEBUG);
+$handler->setFormatter(new ElasticCommonSchemaFormatter());
+$log->pushHandler($handler);
+
+$log->notice('Hi, I am the spec for the ECS logging libraries.');
+
+function f1()
+{
+    throw new RuntimeException('My example exception');
+}
+
+try {
+    f1();
+} catch (RuntimeException $ex) {
+    $log->error(
+        'My example log message',
+        [
+            'error'      => new EcsError($ex),
+            'my_ctx_key' => 'my_ctx_value',
+        ]
+    );
+}

--- a/tests/sample_app/sample_app.php
+++ b/tests/sample_app/sample_app.php
@@ -27,8 +27,9 @@ try {
     $log->error(
         'My example log message',
         [
-            'error'      => new EcsError($ex),
-            'my_ctx_key' => 'my_ctx_value',
+            'error'    => new EcsError($ex),
+            'labels'   => ['my_ctx_key' => 'my_ctx_value'],
+            'trace.id' => 'abc-xyz',
         ]
     );
 }


### PR DESCRIPTION
- Moved `ElasticCommonSchemaFormatter` from `Elastic\Monolog\v2\Formatter` back to `Elastic\Monolog\Formatter`
    - To keep backward compatible with already released `elastic/ecs-logging` 1.0.1
    - For more seamless future support of both Monolog v1 and v2
- To make output compatible with [the latest ECS logging spec](https://github.com/elastic/ecs-logging/tree/master/spec)
    - Extracted `log.level` from `log`
    - Reordered fields
    - Added `ecs.version`
