### PR TITLE
Fixed incompatibilities with the spec

### DIFF
--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -98,24 +98,8 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
             unset($inRecord['context']['user']);
         }
 
-        // Add ECS Labels
-        $inContext = $inRecord['context'];
-        if (!empty($inContext)) {
-            // Context should go to the top of the out record
-            foreach ($inContext as $contextKey => $contextVal) {
-                // label keys should be sanitized
-                if ($contextKey === 'labels') {
-                    $outLabels = [];
-                    foreach ($contextVal as $labelKey => $labelVal) {
-                        $outLabels[str_replace(['.', ' ', '*', '\\'], '_', trim($labelKey))] = $labelVal;
-                    }
-                    $outRecord['labels'] = $outLabels;
-                    continue;
-                }
-
-                $outRecord[$contextKey] = $contextVal;
-            }
-        }
+        self::formatContext($inRecord['extra'], /* ref */ $outRecord);
+        self::formatContext($inRecord['context'], /* ref */ $outRecord);
 
         // Add ECS Tags
         if (empty($this->tags) === false) {
@@ -123,5 +107,23 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
         }
 
         return $this->toJson($outRecord) . "\n";
+    }
+
+    private static function formatContext(array $inContext, array &$outRecord): void
+    {
+        // Context should go to the top of the out record
+        foreach ($inContext as $contextKey => $contextVal) {
+            // label keys should be sanitized
+            if ($contextKey === 'labels') {
+                $outLabels = [];
+                foreach ($contextVal as $labelKey => $labelVal) {
+                    $outLabels[str_replace(['.', ' ', '*', '\\'], '_', trim($labelKey))] = $labelVal;
+                }
+                $outRecord['labels'] = $outLabels;
+                continue;
+            }
+
+            $outRecord[$contextKey] = $contextVal;
+        }
     }
 }

--- a/src/Elastic/Types/Error.php
+++ b/src/Elastic/Types/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUndefinedClassInspection */
+
 declare(strict_types=1);
 
 // Licensed to Elasticsearch B.V under one or more agreements.
@@ -16,46 +18,38 @@ use Throwable;
  *
  * @version v1.x
  *
- * @see https://www.elastic.co/guide/en/ecs/current/ecs-error.html
+ * @see     https://www.elastic.co/guide/en/ecs/current/ecs-error.html
  *
- * @author Philip Krauss <philip.krauss@elastic.co>
+ * @author  Philip Krauss <philip.krauss@elastic.co>
  */
 class Error extends BaseType implements JsonSerializable
 {
-
-    /**
-     * @var array
-     */
-    private $data;
+    /** @var Throwable */
+    private $throwable;
 
     /**
      * @param Throwable $throwable
      */
     public function __construct(Throwable $throwable)
     {
-        $this->data = [
-            'error'   => [
-                'type'        => get_class($throwable),
-                'message'     => $throwable->getMessage(),
-                'code'        => $throwable->getCode(),
-                'stack_trace' => explode(PHP_EOL, $throwable->getTraceAsString()),
-            ],
-            'log'     => [
-                'origin' => [
-                    'file' => [
-                        'name' => $throwable->getFile(),
-                        'line' => $throwable->getLine(),
-                    ],
-                ],
-            ],
+        $this->throwable = $throwable;
+    }
+
+    public static function serialize(Throwable $throwable): array
+    {
+        return [
+            'type'        => get_class($throwable),
+            'message'     => $throwable->getMessage(),
+            'code'        => $throwable->getCode(),
+            'stack_trace' => $throwable->__toString(),
         ];
     }
 
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
-        return $this->data;
+        return self::serialize($this->throwable);
     }
 }

--- a/tests/Elastic/BaseTestCase.php
+++ b/tests/Elastic/BaseTestCase.php
@@ -39,7 +39,7 @@ class BaseTestCase extends TestCase
     /**
      * @return InvalidArgumentException
      */
-    protected function generateException(): Throwable
+    protected static function generateException(): Throwable
     {
         return new InvalidArgumentException('This is a InvalidArgumentException', 42);
     }

--- a/tests/Elastic/HelperForMonolog.php
+++ b/tests/Elastic/HelperForMonolog.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic\Tests;
+
+use Monolog\Logger;
+
+class HelperForMonolog
+{
+    public static function logEmergency(Logger $logger, string $message, array &$logOrigin): void
+    {
+        $logOrigin['class'] = __CLASS__;
+        $logOrigin['function'] = __FUNCTION__;
+        $logOrigin['file'] = __FILE__;
+        $logOrigin['line'] = __LINE__ + 1;
+        $logger->emergency($message);
+    }
+}

--- a/tests/Elastic/Monolog/Formatter/MockHandler.php
+++ b/tests/Elastic/Monolog/Formatter/MockHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic\Tests\Monolog\Formatter;
+
+use Monolog\Handler\AbstractProcessingHandler;
+
+class MockHandler extends AbstractProcessingHandler
+{
+    /** @var array<array> */
+    public $records = [];
+
+    protected function write(array $record): void
+    {
+        $this->records[] = $record;
+    }
+}

--- a/tests/Elastic/Monolog/Formatter/TestHelper.php
+++ b/tests/Elastic/Monolog/Formatter/TestHelper.php
@@ -1,0 +1,75 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic\Tests\Monolog\Formatter;
+
+use Closure;
+use DateTimeImmutable;
+use Elastic\Monolog\Formatter\ElasticCommonSchemaFormatter;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class TestHelper
+{
+    /** @var string */
+    public $loggerName = 'MyLogger';
+
+    /** @var Closure|null */
+    public $adaptLogger = null;
+
+    /** @var array */
+    public $expectedAdditionalTopLevelKeys = [];
+
+    public function run(int $logLevel, string $message, array $context = []): array
+    {
+        $logger = new Logger($this->loggerName);
+        $handler = new MockHandler();
+        $handler->setFormatter(new ElasticCommonSchemaFormatter());
+        $logger->pushHandler($handler);
+        if ($this->adaptLogger !== null) {
+            ($this->adaptLogger)($logger);
+        }
+
+        $timeBefore = new DateTimeImmutable();
+        $logger->addRecord($logLevel, $message, $context);
+        $timeAfter = new DateTimeImmutable();
+
+        TestCase::assertCount(1, $handler->records);
+        TestCase::assertArrayHasKey('formatted', $handler->records[0]);
+        $encodedJson = $handler->records[0]['formatted'];
+        $decodedJson = json_decode($encodedJson, /* $associative */ true);
+        TestCase::assertIsArray($decodedJson);
+
+        $expectedTopLevelKeys = array_merge(
+            ['@timestamp', 'log.level', 'message', 'ecs.version', 'log'],
+            $this->expectedAdditionalTopLevelKeys
+        );
+        TestCase::assertEquals($expectedTopLevelKeys, array_keys($decodedJson));
+
+        $timestamp = new DateTimeImmutable($decodedJson['@timestamp']);
+        TestCase::assertGreaterThanOrEqual($timeBefore, $timestamp);
+        TestCase::assertLessThanOrEqual($timeAfter, $timestamp);
+
+        TestCase::assertEquals(Logger::getLevelName($logLevel), $decodedJson['log.level']);
+
+        TestCase::assertEquals(ElasticCommonSchemaFormatterTest::ECS_VERSION, $decodedJson['ecs.version']);
+
+        TestCase::assertEquals($message, $decodedJson['message']);
+
+        TestCase::assertEquals(['logger'], array_keys($decodedJson['log']));
+        TestCase::assertSame($this->loggerName, $decodedJson['log']['logger']);
+
+        foreach ($context as $ctxKey => $ctxVal) {
+            TestCase::assertArrayHasKey($ctxKey, $decodedJson[0]);
+        }
+
+        return $decodedJson;
+    }
+}

--- a/tests/Elastic/Types/ErrorTest.php
+++ b/tests/Elastic/Types/ErrorTest.php
@@ -8,25 +8,25 @@ declare(strict_types=1);
 
 namespace Elastic\Tests\Types;
 
-use \Elastic\Tests\BaseTestCase;
-use Elastic\Types\Error;
+use Elastic\Tests\BaseTestCase;
 use Elastic\Types\BaseType;
+use Elastic\Types\Error;
 
 /**
  * Test: Error (Type)
  *
  * @version v1.x
  *
- * @see Elastic\Types\Error
+ * @see     \Elastic\Types\Error
  *
- * @author Philip Krauss <philip.krauss@elastic.co>
+ * @author  Philip Krauss <philip.krauss@elastic.co>
  */
 class ErrorTest extends BaseTestCase
 {
 
     /**
-     * @covers Elastic\Types\Error::__construct
-     * @covers Elastic\Types\Error::jsonSerialize
+     * @covers \Elastic\Types\Error::__construct
+     * @covers \Elastic\Types\Error::jsonSerialize
      */
     public function testSerialization()
     {
@@ -39,26 +39,15 @@ class ErrorTest extends BaseTestCase
         $decoded = $error->toArray();
         $this->assertIsArray($decoded);
 
-        $this->assertArrayHasKey('error', $decoded);
-        $this->assertArrayHasKey('type', $decoded['error']);
-        $this->assertArrayHasKey('message', $decoded['error']);
-        $this->assertArrayHasKey('code', $decoded['error']);
-        $this->assertArrayHasKey('stack_trace', $decoded['error']);
-
-        $this->assertArrayHasKey('log', $decoded);
-        $this->assertArrayHasKey('origin', $decoded['log']);
-        $this->assertArrayHasKey('file', $decoded['log']['origin']);
-        $this->assertArrayHasKey('name', $decoded['log']['origin']['file']);
-        $this->assertArrayHasKey('line', $decoded['log']['origin']['file']);
+        $this->assertArrayHasKey('type', $decoded);
+        $this->assertArrayHasKey('message', $decoded);
+        $this->assertArrayHasKey('code', $decoded);
+        $this->assertArrayHasKey('stack_trace', $decoded);
 
         // Values Correct ?
-        $this->assertEquals('BaseTestCase.php', basename($decoded['log']['origin']['file']['name']));
-        $this->assertEquals(44, $decoded['log']['origin']['file']['line']);
-
-        $this->assertEquals('InvalidArgumentException', $decoded['error']['type']);
-        $this->assertEquals($t->getMessage(), $decoded['error']['message']);
-        $this->assertEquals($t->getCode(), $decoded['error']['code']);
-        $this->assertIsArray($decoded['error']['stack_trace']);
-        $this->assertNotEmpty($decoded['error']['stack_trace']);
+        $this->assertEquals('InvalidArgumentException', $decoded['type']);
+        $this->assertEquals($t->getMessage(), $decoded['message']);
+        $this->assertEquals($t->getCode(), $decoded['code']);
+        $this->assertSame($t->__toString(), $decoded['stack_trace']);
     }
 }

--- a/tests/sample_app/sample_app.php
+++ b/tests/sample_app/sample_app.php
@@ -8,6 +8,7 @@ use Elastic\Monolog\Formatter\ElasticCommonSchemaFormatter;
 use Elastic\Types\Error as EcsError;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Monolog\Processor\IntrospectionProcessor;
 
 echo 'Current timezone: ' . date_default_timezone_get() . PHP_EOL;
 if (date_default_timezone_set('America/New_York') !== true) {
@@ -15,27 +16,33 @@ if (date_default_timezone_set('America/New_York') !== true) {
 }
 echo 'Current timezone: ' . date_default_timezone_get() . PHP_EOL;
 
-$log = new Logger('MyLogger');
-$handler = new StreamHandler('php://stdout', Logger::DEBUG);
-$handler->setFormatter(new ElasticCommonSchemaFormatter());
-$log->pushHandler($handler);
-
-$log->notice('Hi, I am the spec for the ECS logging libraries.');
-
 function f1()
 {
     throw new RuntimeException('My example exception');
 }
 
-try {
-    f1();
-} catch (RuntimeException $ex) {
-    $log->error(
-        'My example log message',
-        [
-            'error'    => new EcsError($ex),
-            'labels'   => ['my_ctx_key' => 'my_ctx_value'],
-            'trace.id' => 'abc-xyz',
-        ]
-    );
+function main()
+{
+    $logger = new Logger('MyLogger');
+    $handler = new StreamHandler('php://stdout', Logger::DEBUG);
+    $handler->setFormatter(new ElasticCommonSchemaFormatter());
+    $logger->pushHandler($handler);
+    $logger->pushProcessor(new IntrospectionProcessor());
+
+    $logger->notice('Hi, I am the spec for the ECS logging libraries.');
+
+    try {
+        f1();
+    } catch (RuntimeException $ex) {
+        $logger->error(
+            'My example log message',
+            [
+                'error'    => new EcsError($ex),
+                'labels'   => ['my_ctx_key' => 'my_ctx_value'],
+                'trace.id' => 'abc-xyz',
+            ]
+        );
+    }
 }
+
+main();


### PR DESCRIPTION
- [x] Fixed incorrect use of `log.origin` for `error` (`log.origin` should refer to location of log statement not where `error` was thrown)
- [x] Added support for 'extra' info. This allows to support Monolog processors such as [`TagProcessor`](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Processor/TagProcessor.php).
- [x] Added support for `log.origin`. This allows to support Monolog [`IntrospectionProcessor`](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Processor/IntrospectionProcessor.php).