### PR TITLE
Updated identifier where %i does not exists

### DIFF
--- a/tests/Elastic/Types/UserTest.php
+++ b/tests/Elastic/Types/UserTest.php
@@ -107,7 +107,7 @@ class UserTest extends BaseTestCase
      */
     public function testSeralizeFullName()
     {
-        $expected = sprintf("Max Mustermann the %ith", rand(4, 9));
+        $expected = sprintf("Max Mustermann the %dth", rand(4, 9));
 
         $user = new User();
         $user->setFullName($expected);


### PR DESCRIPTION
I noticed that the user type test is failing due to a wrongly used sprintf identifier.