### PR TITLE
Set "ecs.version" via ElasticCommonSchemaFormatter::__construct()

### DIFF
--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -25,7 +25,8 @@ use Throwable;
  */
 class ElasticCommonSchemaFormatter extends NormalizerFormatter
 {
-    private const ECS_VERSION = '1.2.0';
+    /** @var string */
+    private $ecsVersion;
 
     private static $logOriginKeys = ['file' => true, 'line' => true, 'class' => true, 'function' => true];
 
@@ -42,10 +43,11 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
     /**
      * @param array $tags optional tags to enrich the log lines
      */
-    public function __construct(array $tags = [])
+    public function __construct(array $tags = [], $ecsVersion = '1.2.0')
     {
         parent::__construct('Y-m-d\TH:i:s.uP');
         $this->tags = $tags;
+        $this->ecsVersion = $ecsVersion;
     }
 
     public function useLogOriginFromContext(bool $useLogOriginFromContext): self
@@ -95,7 +97,7 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
         }
 
         // Add "ecs.version"
-        $outRecord['ecs.version'] = self::ECS_VERSION;
+        $outRecord['ecs.version'] = $this->ecsVersion;
 
         // Add "log": { "logger": ..., ... }
         $outRecord['log'] = [


### PR DESCRIPTION
Now is ECS_VERSION is const, but I need to set version 1.5.0, easiest way is via constructor like this. My version is backward compatible.

Usage in Laravel:

    class EcsFormatter
    {
        public function __invoke($logger)
        {
            foreach ($logger->getHandlers() as $handler) {
                $handler->setFormatter(new ElasticCommonSchemaFormatter([], '1.5.0'));
            }
        }
    }