### PR TITLE
Monolog and PHP 8 updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php": "^7.2||^8.0",
-        "psr/log": "^1.0.1",
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
 	    "ext-json": "*"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
-        "squizlabs/php_codesniffer": "3.*",
-        "brianium/paratest": "^3.1",
-        "monolog/monolog": "^2.0"
+        "squizlabs/php_codesniffer": "^3.7",
+        "brianium/paratest": "^6.6",
+        "monolog/monolog": "^2.5"
     },
     "autoload": {
         "psr-4": {"Elastic\\": "src/Elastic"}

--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -27,7 +27,7 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
 {
     private const ECS_VERSION = '1.2.0';
 
-    private static $logOriginKeys = ['file' => true, 'line' => true, 'class' => true, 'function' => true];
+    private static $logOriginKeys = ['file' => true, 'line' => true, 'class' => true, 'function' => true, 'callType' => true];
 
     /**
      * @var array
@@ -181,6 +181,13 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
         }
         if (!empty($fileVal)) {
             $originVal['file'] = $fileVal;
+        }
+
+        if (array_key_exists('callType', $inContext)) {
+            $callType = $inContext['callType'];
+            if (is_string($callType)) {
+                $originVal['callType'] = $callType;
+            }
         }
 
         $outFunctionVal = null;

--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -183,13 +183,6 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
             $originVal['file'] = $fileVal;
         }
 
-        if (array_key_exists('callType', $inContext)) {
-            $callType = $inContext['callType'];
-            if (is_string($callType)) {
-                $originVal['callType'] = $callType;
-            }
-        }
-
         $outFunctionVal = null;
         if (array_key_exists('function', $inContext)) {
             $inFunctionVal = $inContext['function'];
@@ -197,7 +190,10 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
                 if (array_key_exists('class', $inContext)) {
                     $inClassVal = $inContext['class'];
                     if (is_string($inClassVal)) {
-                        $outFunctionVal = $inClassVal . '::' . $inFunctionVal;
+                        $callType = array_key_exists('callType', $inContext) && is_string($inContext['callType'])
+                            ? $inContext['callType']
+                            : '::';
+                        $outFunctionVal = $inClassVal . $callType . $inFunctionVal;
                     }
                 }
 

--- a/src/Elastic/Types/BaseType.php
+++ b/src/Elastic/Types/BaseType.php
@@ -10,7 +10,6 @@ namespace Elastic\Types;
 
 class BaseType
 {
-
     /**
      * Get the Popo as array
      *

--- a/src/Elastic/Types/Service.php
+++ b/src/Elastic/Types/Service.php
@@ -21,7 +21,6 @@ use JsonSerializable;
  */
 class Service extends BaseType implements JsonSerializable
 {
-
     /**
      * @var array
      */

--- a/src/Elastic/Types/Tracing.php
+++ b/src/Elastic/Types/Tracing.php
@@ -22,7 +22,6 @@ use JsonSerializable;
  */
 class Tracing extends BaseType implements JsonSerializable
 {
-
     /**
      * Unique identifier of the trace
      *

--- a/src/Elastic/Types/User.php
+++ b/src/Elastic/Types/User.php
@@ -21,7 +21,6 @@ use JsonSerializable;
  */
 class User extends BaseType implements JsonSerializable
 {
-
     /**
      * @var array
      */

--- a/tests/Elastic/BaseTestCase.php
+++ b/tests/Elastic/BaseTestCase.php
@@ -19,7 +19,6 @@ use \Throwable;
  */
 class BaseTestCase extends TestCase
 {
-
     /**
      * @return string
      */

--- a/tests/Elastic/HelperForMonolog.php
+++ b/tests/Elastic/HelperForMonolog.php
@@ -14,6 +14,7 @@ class HelperForMonolog
 {
     public static function logEmergency(Logger $logger, string $message, array &$logOrigin): void
     {
+        $logOrigin['callType'] = '::';
         $logOrigin['class'] = __CLASS__;
         $logOrigin['function'] = __FUNCTION__;
         $logOrigin['file'] = __FILE__;

--- a/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
+++ b/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
@@ -450,7 +450,6 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
             self::assertSame($logOrigin['file'], $decodedJson['log']['origin']['file']['name']);
             self::assertSame($logOrigin['line'], $decodedJson['log']['origin']['file']['line']);
             self::assertSame($logOrigin['class'] . '::' . $logOrigin['function'], $decodedJson['log']['origin']['function']);
-            self::assertSame($logOrigin['callType'], $decodedJson['log']['origin']['callType']);
         } else {
             self::assertArrayNotHasKey('origin', $decodedJson['log']);
         }

--- a/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
+++ b/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
@@ -432,7 +432,7 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
         if ($useLogOriginFromContext) {
             $testHelper->expectedAdditionalLogKeys = ['origin'];
         } else {
-            $testHelper->expectedAdditionalTopLevelKeys = ['file', 'line', 'class', 'function'];
+            $testHelper->expectedAdditionalTopLevelKeys = ['file', 'line', 'class', 'callType', 'function'];
         }
 
         $logOrigin = [];
@@ -450,6 +450,7 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
             self::assertSame($logOrigin['file'], $decodedJson['log']['origin']['file']['name']);
             self::assertSame($logOrigin['line'], $decodedJson['log']['origin']['file']['line']);
             self::assertSame($logOrigin['class'] . '::' . $logOrigin['function'], $decodedJson['log']['origin']['function']);
+            self::assertSame($logOrigin['callType'], $decodedJson['log']['origin']['callType']);
         } else {
             self::assertArrayNotHasKey('origin', $decodedJson['log']);
         }

--- a/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
+++ b/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
@@ -449,7 +449,7 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
         if ($useLogOriginFromContext) {
             self::assertSame($logOrigin['file'], $decodedJson['log']['origin']['file']['name']);
             self::assertSame($logOrigin['line'], $decodedJson['log']['origin']['file']['line']);
-            self::assertSame($logOrigin['class'] . '::' . $logOrigin['function'], $decodedJson['log']['origin']['function']);
+            self::assertSame($logOrigin['class'] . $logOrigin['callType'] . $logOrigin['function'], $decodedJson['log']['origin']['function']);
         } else {
             self::assertArrayNotHasKey('origin', $decodedJson['log']);
         }

--- a/tests/Elastic/Types/BaseTypeTest.php
+++ b/tests/Elastic/Types/BaseTypeTest.php
@@ -23,7 +23,6 @@ use Elastic\Types\BaseType;
  */
 class BaseTypeTest extends BaseTestCase
 {
-
     /**
      * @covers Elastic\Types\BaseType::toArray
      */

--- a/tests/Elastic/Types/ErrorTest.php
+++ b/tests/Elastic/Types/ErrorTest.php
@@ -23,7 +23,6 @@ use Elastic\Types\Error;
  */
 class ErrorTest extends BaseTestCase
 {
-
     /**
      * @covers \Elastic\Types\Error::__construct
      * @covers \Elastic\Types\Error::jsonSerialize

--- a/tests/Elastic/Types/ServiceTest.php
+++ b/tests/Elastic/Types/ServiceTest.php
@@ -23,7 +23,6 @@ use Elastic\Types\BaseType;
  */
 class ServiceTest extends BaseTestCase
 {
-
     /**
      * @covers Elastic\Types\Service::__construct
      * @covers Elastic\Types\Service::jsonSerialize

--- a/tests/Elastic/Types/TracingTest.php
+++ b/tests/Elastic/Types/TracingTest.php
@@ -23,7 +23,6 @@ use Elastic\Types\BaseType;
  */
 class TracingTest extends BaseTestCase
 {
-
     /**
      * @covers Elastic\Types\Tracing::__construct
      * @covers Elastic\Types\Tracing::jsonSerialize

--- a/tests/Elastic/Types/UserTest.php
+++ b/tests/Elastic/Types/UserTest.php
@@ -23,7 +23,6 @@ use Elastic\Types\BaseType;
  */
 class UserTest extends BaseTestCase
 {
-
     /**
      * @covers Elastic\Types\User::__construct
      * @covers Elastic\Types\User::jsonSerialize


### PR DESCRIPTION
This update fixes an issue working with [monolog 2.5](https://github.com/Seldaek/monolog/releases/tag/2.5.0) and above, where the IntrospectionProcessor added a `callType` field to its output. Since the `ElasticCommonSchemaFormatter` does not know about this field, it gets added as a top level key instead of within `log.origin` even when `$useLogOriginFromContext` is set. This can be demonstrated by simply checking out the main branch of this repo and running `composer install && composer test`.

This fixes the issue by adding `callType` to the list of known origin keys and also uses it (if available, so will still work with monolog < 2.5) within the `log.origin.function` field. E.g. `MyClass::myFunction` or `MyClass->myFunction`.

As a minor additional change it also marks compatibility with `psr/log` 2.x and 3.x.