### PR TITLE
Monolog 3 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         php-image:
-          - 7.2-alpine
-          - 7.3-alpine
-          - 7.4-alpine
-          - 8.0-alpine
           - 8.1-alpine
           - 8.2-alpine
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ composer require elastic/ecs-logging
 ```
 
 ## Examples and Usage
-* [Monolog v2.0](https://github.com/elastic/ecs-logging-php/blob/main/docs/Monolog_v2.md)
+* [Monolog v3.0](https://github.com/elastic/ecs-logging-php/blob/main/docs/Monolog_v3.md)
 
 ## Library Support
-* Currently only [Monolog:2.*](https://github.com/Seldaek/monolog) is supported.
+* Currently only [Monolog:3.*](https://github.com/Seldaek/monolog) is supported.
 * The major version of this library is compatible with the major version of ECS.
 
 ## References

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^7.2||^8.0",
-        "psr/log": "^1.0.1",
+        "php": ">=8.1",
+        "psr/log": "^1|^2|3",
 	    "ext-json": "*"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "squizlabs/php_codesniffer": "3.*",
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^3.0",
         "phpunit/phpunit": "^8.5||^9.5||^10"
     },
     "autoload": {

--- a/docs/Monolog_v3.md
+++ b/docs/Monolog_v3.md
@@ -1,4 +1,4 @@
-# Monolog v2.x
+# Monolog v3.x
 
 ## Initialize the Formatter
 ```php

--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -10,12 +10,13 @@ namespace Elastic\Monolog\Formatter;
 
 use Elastic\Types\Error as EcsError;
 use Monolog\Formatter\NormalizerFormatter;
+use Monolog\LogRecord;
 use Throwable;
 
 /**
  * Serializes a log message to the Elastic Common Schema (ECS)
  *
- * @version Monolog v2.x
+ * @version Monolog v3.x
  * @version ECS v1.x
  *
  * @see     https://www.elastic.co/guide/en/ecs/1.4/ecs-log.html
@@ -55,7 +56,7 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
     }
 
     /** @inheritDoc */
-    protected function normalize($data, int $depth = 0)
+    protected function normalize(mixed $data, int $depth = 0): mixed
     {
         if ($depth > $this->maxNormalizeDepth) {
             return parent::normalize($data, $depth);
@@ -79,9 +80,9 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
      * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-base.html
      * @link https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
      */
-    public function format(array $record): string
+    public function format(LogRecord $record): string
     {
-        $inRecord = $this->normalize($record);
+        $inRecord = $this->normalize($record->toArray());
 
         // Build Skeleton with "@timestamp" and "log.level"
         $outRecord = [

--- a/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
+++ b/tests/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatterTest.php
@@ -16,7 +16,9 @@ use Elastic\Monolog\Formatter\ElasticCommonSchemaFormatter;
 use Elastic\Tests\BaseTestCase;
 use Elastic\Tests\HelperForMonolog;
 use Elastic\Types\{Error, Service, Tracing, User};
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Monolog\Processor\IntrospectionProcessor;
 use Monolog\Processor\TagProcessor;
 use Throwable;
@@ -39,15 +41,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
      */
     public function testFormat()
     {
-        $msg = [
-            'level'      => Logger::INFO,
-            'level_name' => 'INFO',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => [],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Info,
+            message: md5(uniqid()),
+            context: [],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -79,15 +80,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
 
     public function testTimezone()
     {
-        $msg = [
-            'level'      => Logger::INFO,
-            'level_name' => 'INFO',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable('2013-11-28T12:34:56.98765', new DateTimeZone('-03:45')),
-            'message'    => md5(uniqid()),
-            'context'    => [],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable('2013-11-28T12:34:56.98765', new DateTimeZone('-03:45')),
+            channel: 'ecs',
+            level: Level::Info,
+            message: md5(uniqid()),
+            context: [],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -108,15 +108,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
     public function testContextWithTracing()
     {
         $tracing = new Tracing($this->generateTraceId(), $this->generateTransactionId());
-        $msg = [
-            'level'      => Logger::NOTICE,
-            'level_name' => 'NOTICE',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => ['tracing' => $tracing],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Notice,
+            message: md5(uniqid()),
+            context: ['tracing' => $tracing],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -143,15 +142,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
         $service->setId(rand(100, 999));
         $service->setName('funky-service-01');
 
-        $msg = [
-            'level'      => Logger::NOTICE,
-            'level_name' => 'NOTICE',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => ['service' => $service],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Notice,
+            message: md5(uniqid()),
+            context: ['service' => $service],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -177,15 +175,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
         $user->setId(rand(100, 999));
         $user->setHash(md5(uniqid()));
 
-        $msg = [
-            'level'      => Logger::NOTICE,
-            'level_name' => 'NOTICE',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => ['user' => $user],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Notice,
+            message: md5(uniqid()),
+            context: ['user' => $user],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -223,15 +220,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
      */
     public function testContextWithError(Throwable $throwable, bool $shouldWrap): void
     {
-        $msg = [
-            'level'      => Logger::ERROR,
-            'level_name' => 'ERROR',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => ['error' => $shouldWrap ? new Error($throwable) : $throwable],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Error,
+            message: md5(uniqid()),
+            context: ['error' => $shouldWrap ? new Error($throwable) : $throwable],
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($msg);
@@ -265,15 +261,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
      */
     public function testTags()
     {
-        $msg = [
-            'level'      => Logger::ERROR,
-            'level_name' => 'ERROR',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => [],
-            'extra'      => [],
-        ];
+        $msg = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Error,
+            message: md5(uniqid()),
+            context: [],
+            extra: []
+        );
 
         $tags = [
             'one',
@@ -332,15 +327,14 @@ class ElasticCommonSchemaFormatterTest extends BaseTestCase
             $inContext['top_level_' . $key] = $key;
         }
 
-        $inRecord = [
-            'level'      => Logger::NOTICE,
-            'level_name' => 'NOTICE',
-            'channel'    => 'ecs',
-            'datetime'   => new DateTimeImmutable("@0"),
-            'message'    => md5(uniqid()),
-            'context'    => $inContext,
-            'extra'      => [],
-        ];
+        $inRecord = new LogRecord(
+            datetime: new DateTimeImmutable("@0"),
+            channel: 'ecs',
+            level: Level::Notice,
+            message: md5(uniqid()),
+            context: $inContext,
+            extra: []
+        );
 
         $formatter = new ElasticCommonSchemaFormatter();
         $doc = $formatter->format($inRecord);

--- a/tests/Elastic/Monolog/Formatter/MockHandler.php
+++ b/tests/Elastic/Monolog/Formatter/MockHandler.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
 namespace Elastic\Tests\Monolog\Formatter;
 
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\LogRecord;
 
 class MockHandler extends AbstractProcessingHandler
 {
-    /** @var array<array> */
-    public $records = [];
+    /** @var array<LogRecord> */
+    public array $records = [];
 
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         $this->records[] = $record;
     }


### PR DESCRIPTION
Hi,

note: this is BC breaking due to the Monolog change, and should target a v2 release

- Add support for monolog3
- Set minimum php version to 8.1
- ~~Add remaining member/parameter/return types~~
- ~~Set BaseType to abstract & implement JsonSerializable~~
- ~~Remove redundant type declarations in comments~~
- ~~Update to Composer 2.5~~
