### PR TITLE
ci: use updatecli with GitHub secrets

### DIFF
--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -5,12 +5,12 @@ scms:
   githubConfig:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
       owner: elastic
       repository: ecs-logging-php
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
 
 actions:

--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -1,5 +1,5 @@
 ---
-# Open a PR if the shared spec files are modified
+# Send PRs to the subscribed ECS Agents if the spec files (JSON) are modified
 name: update-specs
 
 on:
@@ -15,11 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: ./.ci/update-specs.yml
+          command: "apply --config .ci/update-specs.yml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
+      - if: failure()
+        uses: elastic/oblt-actions/slack/send@v1
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-php"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"


### PR DESCRIPTION
Use oblt-actions with GitHub secrets.

No need to use Vault secrets path