### PR TITLE
Update test-reporter workflow

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -17,9 +17,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+      - uses: elastic/oblt-actions/test-report@v1
         with:
-          artifact: test-results            # artifact name
-          name: test-report                 # Name of the check run which will be created
+          artifact: /test-results(.*)/      # artifact name pattern
+          name: 'Test Report $1'            # Name of the check run which will be created
           path: "junit-*.xml"               # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results


### PR DESCRIPTION
This can be updated and re-enabled since https://github.com/elastic/ecs-logging-php/pull/69