### PR TITLE
github-action: use oblt-actions/pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   sanity-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/pre-commit@current
+      - uses: elastic/oblt-actions/pre-commit@v1
   test:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/119 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
