### PR TITLE
use Monolog's FormatterInterface format method original signature

### DIFF
--- a/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
+++ b/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php
@@ -73,14 +73,7 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
         return parent::normalize($data, $depth);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-log.html
-     * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-base.html
-     * @link https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
-     */
-    public function format(LogRecord $record): string
+    public function formatAsArray(LogRecord $record): array
     {
         $inRecord = $this->normalize($record->toArray());
 
@@ -129,7 +122,19 @@ class ElasticCommonSchemaFormatter extends NormalizerFormatter
             $outRecord['tags'] = $this->normalize($this->tags);
         }
 
-        return $this->toJson($outRecord) . "\n";
+        return $outRecord;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-log.html
+     * @link https://www.elastic.co/guide/en/ecs/1.1/ecs-base.html
+     * @link https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
+     */
+    public function format(LogRecord $record)
+    {
+        return $this->toJson($this->formatAsArray($record)) . "\n";
     }
 
     private function formatContext(array $inContext, array &$outRecord): void


### PR DESCRIPTION
the original Monolog's `FormatterInterface` [`format` method signature](https://github.com/Seldaek/monolog/blob/e94000419394ff1bec801dad310432228f9fc19c/src/Monolog/Formatter/FormatterInterface.php#L29) does not impose any return type while the `ElasticCommonSchemaFormatter` does impose a return type of `string`:
https://github.com/elastic/ecs-logging-php/blob/978b848676807e62899097804939b7d90d27eec7/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php#L83
this change removes this limitation so it's possible to override the `format` method and return a different type(ex: array).

the usecase i have here is that i want to combine the `ElasticCommonSchemaFormatter` with a monolog handler that uses the [fluent logger](https://github.com/fluent/fluent-logger-php) to send logs to [fluent-bit](https://fluentbit.io/), fluent-bit's forward protocol accept only messages in [`msgpack` format](https://msgpack.org/index.html), so messages are packed using [msgpack php extension](https://github.com/msgpack/msgpack-php), since the message are encoded in a format other then JSON, there is no need here to encode the `ecs` message to json(currently it's automatically done in the `format` method)
https://github.com/elastic/ecs-logging-php/blob/978b848676807e62899097804939b7d90d27eec7/src/Elastic/Monolog/Formatter/ElasticCommonSchemaFormatter.php#L132
and then later decode it, instead i would need only the formatted array so it can be further packed into a `msgpack` to be sent to fluent-bit.