### PR TITLE
[docs] Add `products` to `docset.yml`

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,6 @@
 project: 'ECS Logging PHP'
+products:
+  - id: ecs-logging
 exclude:
   - Monolog_v3.md
 cross_links:


### PR DESCRIPTION
Related to https://github.com/elastic/docs-builder/issues/1200

Add `products` to `docset.yml` to be used in the search experience.

cc @KOTungseth 