### PR TITLE
docs: add `applies_to` frontmatter and section-level tagging

### DIFF
--- a/docs/Monolog_v3.md
+++ b/docs/Monolog_v3.md
@@ -1,3 +1,9 @@
+---
+applies_to:
+  stack: ga
+  serverless: ga
+---
+
 # Monolog v3.x
 
 ## Initialize the Formatter

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,4 +1,7 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/php/current/intro.html
   - https://www.elastic.co/guide/en/ecs-logging/php/current/index.html

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -1,4 +1,7 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/php/current/setup.html
 navigation_title: Get started
@@ -75,6 +78,11 @@ Logs the following (multi-line formatted for better readability):
 
 
 ## Step 2: Configure Filebeat [setup-step-2]
+
+```{applies_to}
+stack: ga
+serverless: unavailable
+```
 
 :::::::{tab-set}
 


### PR DESCRIPTION
## Summary
Adds mandatory `applies_to` (and `products`) frontmatter to the docs pages and adds section-level applicability where content differs from the page default, per the [Docs Versioning contributor guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs) and [applies_to syntax](https://elastic.github.io/docs-builder/syntax/applies/).

Closes https://github.com/elastic/docs-content-internal/issues/256

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude Sonnet 4.5 using Cursor to double-check the updated files, write PR description