### PR TITLE
ci: remove unused paratest installation from install-composer.sh

### DIFF
--- a/.ci/scripts/install-composer.sh
+++ b/.ci/scripts/install-composer.sh
@@ -18,6 +18,3 @@ if (!hash_equals(\$signature, \$hash)) { \
 php /tmp/installer.php --no-ansi --install-dir=. --filename=composer --version=${COMPOSER_VERSION}; \
 composer --ansi --version --no-interaction; \
 rm -f /tmp/installer.php
-
-## Install dependencies
-composer require --no-progress --no-ansi --dev brianium/paratest


### PR DESCRIPTION
- Removes unused `brianium/paratest` installation from `.ci/scripts/install-composer.sh`
- `paratest` is not referenced anywhere in the test suite — `composer test` runs `parallel-lint`, `phpcs` and `phpunit` only
- `brianium/paratest ^7.8` requires `phpunit ^11.5` which conflicts with the project's `"phpunit/phpunit": "^8.5||^9.5||^10"`, causing CI to fail

